### PR TITLE
Add SerialDeserial for private keys

### DIFF
--- a/src/PrivateKey.cc
+++ b/src/PrivateKey.cc
@@ -17,4 +17,8 @@ std::shared_ptr<PrivateKeyImpl>& PrivateKeyDCRTPoly::GetRef() noexcept
     return m_privateKey;
 }
 
+std::unique_ptr<PrivateKeyDCRTPoly> DCRTPolyGenNullPrivateKey()
+{
+    return std::make_unique<PrivateKeyDCRTPoly>();
+
 } // openfhe

--- a/src/PrivateKey.h
+++ b/src/PrivateKey.h
@@ -22,4 +22,6 @@ public:
     [[nodiscard]] std::shared_ptr<PrivateKeyImpl>& GetRef() noexcept;
 };
 
+[[nodiscard]] std::unique_ptr<PrivateKeyDCRTPoly> DCRTPolyGenNullPrivateKey();
+
 } // openfhe

--- a/src/SerialDeserial.cc
+++ b/src/SerialDeserial.cc
@@ -5,6 +5,7 @@
 #include "Ciphertext.h"
 #include "CryptoContext.h"
 #include "PublicKey.h"
+#include "PrivateKey.h"
 
 namespace openfhe
 {
@@ -235,6 +236,18 @@ bool DCRTPolySerializePublicKeyToFile(const std::string& publicKeyLocation,
     const PublicKeyDCRTPoly& publicKey, const SerialMode serialMode)
 {
     return Serial(publicKeyLocation, publicKey, serialMode);
+}
+
+bool DCRTPolyDeserializePrivateKeyFromFile(const std::string& privateKeyLocation,
+    PrivateKeyDCRTPoly& privateKey, const SerialMode serialMode)
+{
+    return Deserial(privateKeyLocation, privateKey, serialMode);
+}
+
+bool DCRTPolySerializePrivateKeyToFile(const std::string& privateKeyLocation,
+    const PrivateKeyDCRTPoly& privateKey, const SerialMode serialMode)
+{
+    return Serial(privateKeyLocation, privateKey, serialMode);
 }
 
 } // openfhe

--- a/src/SerialDeserial.h
+++ b/src/SerialDeserial.h
@@ -10,6 +10,7 @@ namespace openfhe
 class CiphertextDCRTPoly;
 class CryptoContextDCRTPoly;
 class PublicKeyDCRTPoly;
+class PrivateKeyDCRTPoly;
 
 // Ciphertext
 [[nodiscard]] bool DCRTPolyDeserializeCiphertextFromFile(const std::string& ciphertextLocation,
@@ -54,5 +55,10 @@ class PublicKeyDCRTPoly;
     PublicKeyDCRTPoly& publicKey, const SerialMode serialMode);
 [[nodiscard]] bool DCRTPolySerializePublicKeyToFile(const std::string& publicKeyLocation,
     const PublicKeyDCRTPoly& publicKey, const SerialMode serialMode);
+
+[[nodiscard]] bool DCRTPolyDeserializePrivateKeyFromFile(const std::string& privateKeyLocation,
+    PrivateKeyDCRTPoly& privateKey, const SerialMode serialMode);
+[[nodiscard]] bool DCRTPolySerializePrivateKeyToFile(const std::string& privateKeyLocation,
+    const PrivateKeyDCRTPoly& cryptoContext, const SerialMode serialMode);
 
 } // openfhe

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1054,6 +1054,9 @@ pub mod ffi
     {
         // Generator functions
         fn DCRTPolyGenNullPublicKey() -> UniquePtr<PublicKeyDCRTPoly>;
+    unsafe extern "C++"
+    {
+        fn GetKeyTag(self: &PrivateKeyDCRTPoly) -> UniquePtr<CxxString>;
     }
 
     // Serialize / Deserialize
@@ -1109,6 +1112,12 @@ pub mod ffi
                                                 serialMode: SerialMode) -> bool;
         fn DCRTPolySerializePublicKeyToFile(publicKeyLocation: &CxxString,
                                             publicKey: &PublicKeyDCRTPoly,
+                                            serialMode: SerialMode) -> bool;
+        fn DCRTPolyDeserializePrivateKeyFromFile(privateKeyLocation: &CxxString,
+                                                privateKey: Pin<&mut PrivateKeyDCRTPoly>,
+                                                serialMode: SerialMode) -> bool;
+        fn DCRTPolySerializePrivateKeyToFile(privateKeyLocation: &CxxString,
+                                            privateKey: &PrivateKeyDCRTPoly,
                                             serialMode: SerialMode) -> bool;
     }
 }


### PR DESCRIPTION
It is necessary to be able to store a private key and retrieve it later from disk.